### PR TITLE
Add a version code offset parameter

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -3,6 +3,7 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 app:
   envs:
+  - version_code_offset: $my_version_code_offset
   - BITRISE_BUILD_NUMBER: "43"
   # define these in your .bitrise.secrets.yml
   - my_manifest_path: $my_manifest_path
@@ -25,9 +26,10 @@ workflows:
     - path::./:
         run_if: true
         inputs:
-        - manifest_path: ${my_manifest_path}
+        - manifest_file: ${my_manifest_path}
         - version_code: ${BITRISE_BUILD_NUMBER}
         - version_name: ${my_version_name}
+        - version_code_offset: ${my_version_code_offset}
  
   # ----------------------------------------------------------------
   # --- workflows to Share this step into a Step Library

--- a/step.sh
+++ b/step.sh
@@ -37,6 +37,16 @@ if [ -z "${VERSIONCODE}" ] ; then
 fi
 
 echo "Version code detected: ${VERSIONCODE}"
+if [ ! -z "${version_code_offset}" ] ; then
+  echo " (i) Version code offset: ${version_code_offset}"
+
+  CONFIG_new_version_code=$((${VERSIONCODE} + ${version_code_offset}))
+
+  echo " (i) Version code: ${CONFIG_new_version_code}"
+else
+  echo " (i) Version code: ${CONFIG_new_version_code}"
+fi
+
 
 if [ -z "${VERSIONNAME}" ] ; then
   echo " [!] Could not find current Version Name!"
@@ -53,7 +63,7 @@ echo "Version name detected: ${VERSIONNAME}"
 set -v
 # ---- Set Build Version Code:
 
-sed -i.bak "s/android:versionCode="\"${VERSIONCODE}\""/android:versionCode="\"${version_code}\""/" ${manifest_file}
+sed -i.bak "s/android:versionCode="\"${VERSIONCODE}\""/android:versionCode="\"${CONFIG_new_version_code}\""/" ${manifest_file}
 
 # ---- Set Build Version Code if it was specified:
 if ! [ -z "${version_name}" ] ; then

--- a/step.yml
+++ b/step.yml
@@ -29,6 +29,11 @@ inputs:
       title: "Version Code"
       summary: "Set the android:versionCode to a specified value. Should be integer type."
       is_required: true
+  - version_code_offset:
+    opts:
+      title: "Version Code Offset"
+      description: |
+        This offset will be added to `version code` input's value.
   - version_name: 
     opts:
       title: "Version Name"


### PR DESCRIPTION
This adds an optional parameter to offset the version code. Android projects that may already have a version code larger than the bitrise build number can use this to to pick up right where they left off.

There is also a small fix (manifest_path changed to manifest_file) in bitrise.yml.
