### PR TITLE
Addressing Issue #9: Version Code offset being set against code in AndroidManifest.xml not in Bitrise build

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -40,12 +40,12 @@ echo "Version code detected: ${VERSIONCODE}"
 if [ ! -z "${version_code_offset}" ] ; then
   echo " (i) Version code offset: ${version_code_offset}"
 
-  CONFIG_new_version_code=$((${VERSIONCODE} + ${version_code_offset}))
-
-  echo " (i) Version code: ${CONFIG_new_version_code}"
+  CONFIG_new_version_code=$((${version_code} + ${version_code_offset}))
 else
-  echo " (i) Version code: ${CONFIG_new_version_code}"
+  CONFIG_new_version_code=${version_code}
 fi
+
+echo " (i) Version code: ${CONFIG_new_version_code}"
 
 
 if [ -z "${VERSIONNAME}" ] ; then


### PR DESCRIPTION
Basing offset calculating on the passed in version code from the bitrise build, not the code detected in the manifest that wouldn't be changing.
