### PR TITLE
Fixed Version Code typo

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -23,7 +23,7 @@ fi
 # --- Configs:
 
 echo " (i) Provided Android Manifest path: ${manifest_file}"
-echo " (i) Verson Code: ${version_code}"
+echo " (i) Version Code: ${version_code}"
 if ! [ -z "${version_name}" ] ; then
   echo " (i) Version Name: ${version_name}"
 fi


### PR DESCRIPTION
Typo in log output of `step.sh`, noticed while using this step for some apps in Bitrise. This change definitely qualifies for a 2.0 bump 🚀. (First PR to a fork, so if I am doing this wrong feel free to use caps lock).