### PR TITLE
Update step.yml to reflect versionname false

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -39,4 +39,4 @@ inputs:
     opts:
       title: "Version Name"
       summary: "Set the android:versionName to a specified value that is usually display. For example: 1.0.5"
-      is_required: true
+      is_required: false


### PR DESCRIPTION
```
echo " (i) Provided Android Manifest path: ${manifest_file}"
echo " (i) Version Code: ${version_code}"
if ! [ -z "${version_name}" ] ; then
  echo " (i) Version Name: ${version_name}"
fi
```

As you can see above, the version name is not required in the actual bitrise step. However, it says that it is required on bitrise.
![image](https://user-images.githubusercontent.com/1022815/39404185-0d5a25dc-4b5c-11e8-8736-6c89e5e556a1.png)
